### PR TITLE
Final v2.0.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.0 (2017-10-03)
+* [Wade Peacock] - Updating our fork of consul-template. To divergent.
+                 - Make it work with nssm ~> 4.0
+                 - Removed duplicated """  that nssm ~> 4.0 litterally puts in
 1.0.0
 -----
 - [Riley Shott] - Updated wrapper cookbook to reflect upstream changes. Now requires consul_template >= 1.0.0

--- a/libraries/consul_template_service.rb
+++ b/libraries/consul_template_service.rb
@@ -49,7 +49,7 @@ module ConsulTemplateCookbook
 
       def command
         if windows?
-          %(-config """#{conf_dir}""")
+          %(-config "#{conf_dir}")
         else
           "#{program} -config #{conf_dir}"
         end

--- a/libraries/consul_template_service_windows.rb
+++ b/libraries/consul_template_service_windows.rb
@@ -33,7 +33,7 @@ module ConsulTemplateCookbook
             extend ::ConsulTemplateCookbook::NSSMHelpers
             action :install
             program new_resource.program
-            params new_resource.nssm_params.select { |_k, v| v != '' }
+            parameters new_resource.nssm_params.select { |_k, v| v != '' }
             args new_resource.command
             not_if { nssm_service_installed? }
           end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,18 +4,19 @@ maintainer_email 'Riley Shott <riley.shott@visioncritical.com>'
 license          'MIT'
 description      'Installs/Configures consul_template'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.0'
+version          '2.0.0'
 
 supports 'ubuntu', '>= 12.04'
 supports 'redhat', '>= 6.4'
 supports 'centos', '>= 6.4'
+supports 'oracle', '>= 6.4'
 supports 'windows'
 supports 'freebsd'
 
 depends 'poise', '~> 2.6'
 depends 'poise-service', '~> 1.4'
 depends 'rubyzip', '~> 1.0'
-depends 'nssm', '~> 2.0'
+depends 'nssm', '~> 4.0'
 
 source_url 'https://github.com/visioncritical/consul_template' if respond_to?(:source_url)
 issues_url 'https://github.com/visioncritical/consul_template/issues' if respond_to?(:issues_url)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: consul_template
 # Recipe:: default
 #
-# Copyright 2016, Vision Critical Inc.
+# Copyright 2017, Vision Critical Inc.
 #
 
 ###
@@ -12,9 +12,6 @@ version = node['consul_template']['version']
 service_name = node['consul_template']['service_name']
 user = node['consul_template']['service']['user']
 group = node['consul_template']['service']['group']
-
-# Windows only
-node.default['nssm']['install_location'] = '%WINDIR%'
 
 ###
 # Resources


### PR DESCRIPTION
```
2.0.0 (2017-10-03)
* [Wade Peacock] - Updating our fork of consul-template. To divergent.
                 - Make it work with nssm ~> 4.0
                 - Removed duplicated """  that nssm ~> 4.0 litterally puts in
```